### PR TITLE
Gate pre-injection CSS behind runtime checks

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,6 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "css": ["src/content/pre-inject.css"],
       "js": ["src/content/index.js"],
       "run_at": "document_start"
     }

--- a/scripts/build-scripts.cjs
+++ b/scripts/build-scripts.cjs
@@ -65,14 +65,6 @@ async function buildAll() {
     });
     console.log('✔ content script built with esbuild -> dist/src/content/index.js');
 
-    // Copy pre-inject.css to dist
-    const preInjectCssSource = 'src/content/pre-inject.css';
-    const preInjectCssDest = 'dist/src/content/pre-inject.css';
-    if (existsSync(preInjectCssSource)) {
-      copyFileSync(preInjectCssSource, preInjectCssDest);
-      console.log('✔ pre-inject.css copied -> dist/src/content/pre-inject.css');
-    }
-
     // Clean up temp file
     const fs = require('fs');
     if (fs.existsSync(tempContentPath)) {


### PR DESCRIPTION
## Summary
- remove unconditional pre-injection stylesheet from the manifest and bundle process
- dynamically add and clean up pre-injection CSS only when a page is eligible for theming
- ensure skipped pages clear any early styles so detection and cleanup stay accurate

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691fdab582308330b8564e5e7a435bca)