### PR TITLE
Refine dark detection and disable irrelevant popup controls

### DIFF
--- a/src/popup/algorithm-controls.ts
+++ b/src/popup/algorithm-controls.ts
@@ -1,0 +1,32 @@
+// src/popup/algorithm-controls.ts
+import type { Mode } from "../types/settings";
+
+const sliderIds = ["brightness", "contrast", "sepia", "grayscale", "blueShift"] as const;
+
+export type SliderId = (typeof sliderIds)[number];
+
+/**
+ * Map of which sliders apply to each algorithm.
+ * Only the Chroma-Semantic engine exposes fine-tuning in the current UI,
+ * so sliders are disabled for the other algorithms to avoid confusion.
+ */
+export const sliderModeMap: Record<Mode, SliderId[]> = {
+  "photon-inverter": [],
+  "dom-walker": [],
+  "chroma-semantic": [...sliderIds]
+};
+
+export function updateAlgorithmControlState(activeMode: Mode, root: ParentNode = document): void {
+  const enabled = new Set(sliderModeMap[activeMode] || []);
+
+  sliderIds.forEach((id) => {
+    const input = root.querySelector<HTMLInputElement>(`#${id}`);
+    if (!input) return;
+
+    const shouldEnable = enabled.has(id);
+    input.disabled = !shouldEnable;
+
+    const row = input.closest<HTMLElement>(".slider-row");
+    row?.classList.toggle("disabled", !shouldEnable);
+  });
+}

--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -1,6 +1,7 @@
 // src/popup/index.ts
 import type { Settings } from "../types/settings";
 import { getSettings, setSettings, originFromUrl } from "../utils/storage";
+import { updateAlgorithmControlState } from "./algorithm-controls";
 
 const $ = (sel: string) => document.querySelector(sel) as HTMLElement;
 const $$ = (sel: string) => document.querySelectorAll(sel);
@@ -66,6 +67,8 @@ async function init() {
     amoled.checked = st.amoled;
     optimizer.checked = st.optimizerEnabled;
     detectDark.checked = st.detectDarkSites;
+
+    updateAlgorithmControlState(st.mode);
 
     // Update mode buttons
     modeButtons.forEach((btn) => {

--- a/src/popup/style.css
+++ b/src/popup/style.css
@@ -247,6 +247,10 @@ body {
   gap: 3px;
 }
 
+.slider-row.disabled {
+  opacity: 0.45;
+}
+
 .slider-label {
   display: flex;
   align-items: baseline;

--- a/src/utils/dark-detection.ts
+++ b/src/utils/dark-detection.ts
@@ -2,8 +2,8 @@
 
 /**
  * Detect if a site is already using a dark theme
- * Uses multiple heuristics:
- * 1. Check if site responds to prefers-color-scheme: dark
+ * Uses multiple heuristics based solely on the rendered page:
+ * 1. Check explicit dark theme markers in the DOM
  * 2. Check average background luminance
  */
 
@@ -140,26 +140,6 @@ export function getAverageBackgroundLuminance(): number {
 }
 
 /**
- * Check if the site declares support for dark mode via media query
- */
-export function siteDeclaresColorScheme(): boolean {
-  if (typeof window === "undefined" || !window.matchMedia) return false;
-
-  // Check if the site is responding to prefers-color-scheme
-  const darkMq = window.matchMedia("(prefers-color-scheme: dark)");
-  
-  // If the media query matches, check if CSS actually changes
-  // We do this by comparing a known element's background in both modes
-  if (darkMq.matches) {
-    debugSync('[Dark Detection] Site responds to prefers-color-scheme: dark');
-    return true;
-  }
-
-  debugSync('[Dark Detection] Site does not respond to prefers-color-scheme: dark');
-  return false;
-}
-
-/**
  * Check for common dark theme indicators in HTML/CSS classes and attributes
  * Including meta tags and color-scheme properties as per consultant spec
  */
@@ -241,19 +221,12 @@ export function isAlreadyDarkTheme(): boolean {
   }
 
   const avgLuminance = getAverageBackgroundLuminance();
-  const declaresColorScheme = siteDeclaresColorScheme();
 
   debugSync('[Dark Detection] Average luminance:', avgLuminance, '(threshold:', DARK_THRESHOLD + ')');
 
   // If average luminance is dark, consider it a dark site
   if (avgLuminance < DARK_THRESHOLD) {
     debugSync('[Dark Detection] Result: DARK (luminance below threshold)');
-    return true;
-  }
-
-  // If site declares color scheme support and prefers-color-scheme is dark
-  if (declaresColorScheme) {
-    debugSync('[Dark Detection] Result: DARK (declares color scheme)');
     return true;
   }
 

--- a/tests/popup-algorithm-controls.test.ts
+++ b/tests/popup-algorithm-controls.test.ts
@@ -1,0 +1,63 @@
+// tests/popup-algorithm-controls.test.ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { JSDOM } from "jsdom";
+import { updateAlgorithmControlState, sliderModeMap } from "../src/popup/algorithm-controls";
+
+const sliderTemplate = `
+  <div class="sliders">
+    <div class="slider-row"><input type="range" id="brightness" /></div>
+    <div class="slider-row"><input type="range" id="contrast" /></div>
+    <div class="slider-row"><input type="range" id="sepia" /></div>
+    <div class="slider-row"><input type="range" id="grayscale" /></div>
+    <div class="slider-row"><input type="range" id="blueShift" /></div>
+  </div>
+`;
+
+describe("popup algorithm control state", () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = new JSDOM(sliderTemplate);
+  });
+
+  it("enables sliders for the Chroma-Semantic engine", () => {
+    const { document } = dom.window;
+
+    updateAlgorithmControlState("chroma-semantic", document);
+
+    sliderModeMap["chroma-semantic"].forEach((id) => {
+      const input = document.querySelector<HTMLInputElement>(`#${id}`)!;
+      const row = input.closest<HTMLElement>(".slider-row")!;
+
+      expect(input.disabled).toBe(false);
+      expect(row.classList.contains("disabled")).toBe(false);
+    });
+  });
+
+  it("disables all sliders for Photon Inverter", () => {
+    const { document } = dom.window;
+
+    updateAlgorithmControlState("photon-inverter", document);
+
+    document.querySelectorAll<HTMLInputElement>("input[type='range']").forEach((input) => {
+      const row = input.closest<HTMLElement>(".slider-row")!;
+
+      expect(input.disabled).toBe(true);
+      expect(row.classList.contains("disabled")).toBe(true);
+    });
+  });
+
+  it("disables all sliders for DOM Walker", () => {
+    const { document } = dom.window;
+
+    updateAlgorithmControlState("dom-walker", document);
+
+    document.querySelectorAll<HTMLInputElement>("input[type='range']").forEach((input) => {
+      const row = input.closest<HTMLElement>(".slider-row")!;
+
+      expect(input.disabled).toBe(true);
+      expect(row.classList.contains("disabled")).toBe(true);
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- remove prefers-color-scheme weighting from dark theme detection to rely solely on DOM analysis
- add algorithm-aware popup control state handling to disable irrelevant sliders and gray them out
- add tests covering popup control state per algorithm

## Testing
- npm run lint
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a480c5e48330a395aa7485bca7cd)