### PR TITLE
Reconnect sliders and reset modes on algorithm changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Agent Guide
+
+This repository is a browser extension built with TypeScript and Vite. Key areas:
+
+- **Popup UI**: `src/popup/` controls the popup sliders and toggles. The popup sends `udr:settings-updated` messages to the active tab.
+- **Content scripts**: `src/content/` contains algorithms and the main entry (`index.ts`) that reads settings and applies the selected algorithm.
+- **Algorithms**: Photon inverter (`src/content/algorithms/photon-inverter.ts`), DOM walker (`src/content/algorithms/dom-walker.ts`), and Chroma semantic (`src/content/algorithms/chroma-semantic.ts`).
+- **Shared CSS builder**: `src/content/style-template.ts` builds the injected CSS using brightness/contrast/etc.
+
+Useful commands:
+- Run tests: `npm test`
+- Run lint: `npm run lint`
+- Build extension: `npm run build`
+
+Notes from initial exploration:
+- No existing `AGENTS.md` files; this file applies repo-wide.
+- Tests and lint already set up in `package.json`.
+- Settings changes propagate through `udr:settings-updated` messages handled in `src/content/index.ts`.

--- a/src/content/algorithms/photon-inverter.ts
+++ b/src/content/algorithms/photon-inverter.ts
@@ -11,32 +11,30 @@
  */
 
 import type { Settings } from "../../types/settings";
+import { STYLE_TAG_ID } from "../../utils/defaults";
 import { debugSync } from "../../utils/logger";
+import { buildCss, ensureStyleTag } from "../style-template";
 
 const DARK_THEME_SNIPPET_ID = "dark-theme-snippet";
+
+function hueRotateFromBlueShift(blueShift: number): number {
+  return Math.round((blueShift / 100) * 180);
+}
 
 /**
  * Generate CSS for the new Photon Inverter algorithm
  * Uses simple invert(100%) on :root with image/video re-inversion
  */
-export function generatePhotonInverterCSS(_settings: Settings): string {
-  // Simple CSS inversion approach from the bookmarklet
-  // Note: settings like brightness/contrast are not used in this simplified version
-  // to match the bookmarklet behavior
-  return `
-:root {
-  background-color: #fefefe;
-  filter: invert(100%);
-}
-
-* {
-  background-color: inherit;
-}
-
-img:not([src*=".svg"]), video {
-  filter: invert(100%);
-}
-  `.trim();
+export function generatePhotonInverterCSS(settings: Settings): string {
+  return buildCss({
+    brightness: settings.brightness,
+    contrast: settings.contrast,
+    sepia: settings.sepia,
+    grayscale: settings.grayscale,
+    hueRotateDeg: hueRotateFromBlueShift(settings.blueShift),
+    amoled: settings.amoled,
+    invert: true
+  });
 }
 
 /**
@@ -45,35 +43,12 @@ img:not([src*=".svg"]), video {
  */
 export function applyPhotonInverter(settings: Settings): void {
   debugSync('[Photon Inverter] Applying dark theme with new CSS inversion logic');
-  
+
   const css = generatePhotonInverterCSS(settings);
 
-  let styleTag = document.getElementById(DARK_THEME_SNIPPET_ID) as HTMLStyleElement;
-  if (!styleTag) {
-    styleTag = document.createElement("style");
-    styleTag.type = "text/css";
-    styleTag.id = DARK_THEME_SNIPPET_ID;
-    
-    const head = document.head || document.querySelector('head');
-    if (head) {
-      head.appendChild(styleTag);
-      debugSync('[Photon Inverter] Created new <style> tag with id="dark-theme-snippet"');
-    } else {
-      debugSync('[Photon Inverter] ⚠️ No <head> element found, cannot inject styles');
-      return;
-    }
-  } else {
-    debugSync('[Photon Inverter] Updating existing <style> tag');
-  }
-  
-  // Set CSS content
-  if (styleTag.styleSheet) {
-    // IE support (legacy)
-    (styleTag.styleSheet as { cssText: string }).cssText = css;
-  } else {
-    styleTag.textContent = css;
-  }
-  
+  const styleTag = ensureStyleTag();
+  styleTag.textContent = css;
+
   document.documentElement.setAttribute("data-udr-mode", "photon-inverter");
   debugSync('[Photon Inverter] CSS applied successfully');
 }
@@ -84,10 +59,16 @@ export function applyPhotonInverter(settings: Settings): void {
  */
 export function removePhotonInverter(): void {
   debugSync('[Photon Inverter] Removing dark theme snippet');
-  
-  const styleTag = document.getElementById(DARK_THEME_SNIPPET_ID);
+
+  const legacyTag = document.getElementById(DARK_THEME_SNIPPET_ID);
+  if (legacyTag?.parentNode) {
+    legacyTag.parentNode.removeChild(legacyTag);
+    debugSync('[Photon Inverter] Removed <style id="dark-theme-snippet">');
+  }
+
+  const styleTag = document.getElementById(STYLE_TAG_ID);
   if (styleTag?.parentNode) {
     styleTag.parentNode.removeChild(styleTag);
-    debugSync('[Photon Inverter] Removed <style id="dark-theme-snippet">');
+    debugSync('[Photon Inverter] Removed <style id="udr-style">');
   }
 }

--- a/src/content/style-template.ts
+++ b/src/content/style-template.ts
@@ -19,11 +19,13 @@ export function buildCss(vars: {
   grayscale: number;  // %
   hueRotateDeg: number;
   amoled: boolean;
-  mode: "dynamic" | "static";
+  invert: boolean;
 }) {
-  const { brightness, contrast, sepia, grayscale, hueRotateDeg, amoled } = vars;
+  const { brightness, contrast, sepia, grayscale, hueRotateDeg, amoled, invert } = vars;
 
-  const filter = `invert(1) hue-rotate(180deg) brightness(${brightness}%) contrast(${contrast}%) sepia(${sepia}%) grayscale(${grayscale}%) hue-rotate(${hueRotateDeg}deg)`;
+  const adjustment = `brightness(${brightness}%) contrast(${contrast}%) sepia(${sepia}%) grayscale(${grayscale}%) hue-rotate(${hueRotateDeg}deg)`;
+  const filter = invert ? `invert(1) hue-rotate(180deg) ${adjustment}` : adjustment;
+  const mediaFilter = invert ? "invert(1) hue-rotate(180deg)" : "none";
 
   // AMOLED: force #000 backgrounds
   const amoledCss = amoled
@@ -34,21 +36,28 @@ html, body, body *:not(img):not(video):not(canvas):not(svg):not([data-udr-skip])
 }`
     : "";
 
-  return `
-/* UltraDark Reader injected CSS */
-:root { --udr-filter: ${filter}; }
-html[udr-applied="true"] {
-  filter: var(--udr-filter) !important;
-  background-color: #111 !important;
-}
+  const mediaReinvert = invert
+    ? `
 html[udr-applied="true"] img,
 html[udr-applied="true"] video,
 html[udr-applied="true"] canvas,
 html[udr-applied="true"] svg,
 html[udr-applied="true"] picture,
 html[udr-applied="true"] [role="img"] {
-  filter: invert(1) hue-rotate(180deg) !important; /* re-invert media */
+  filter: ${mediaFilter} !important; /* re-invert media */
+}`
+    : "";
+
+  const background = invert ? "background-color: #111 !important;" : "";
+
+  return `
+/* UltraDark Reader injected CSS */
+:root { --udr-filter: ${filter}; }
+html[udr-applied="true"] {
+  filter: var(--udr-filter) !important;
+  ${background}
 }
+${mediaReinvert}
 ${amoledCss}
 
 /* Prevent double-inverting extension UIs and iframes */


### PR DESCRIPTION
## Summary
- apply brightness/contrast/sepia/grayscale/blue-shift sliders through the injected CSS filter pipeline and photon inverter algorithm
- reset previous algorithm artifacts before reapplying so mode switches update immediately without lingering inversion or inline styles
- add a repo-wide AGENTS.md with quickstart notes and command references

## Testing
- npm test
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69203d2d43948330af1d0d03ce6f2b5f)