### PR TITLE
Add document_start bootstrap and idle photon inverter pass

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,8 +26,13 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["src/content/index.js"],
+      "js": ["src/content/early.js"],
       "run_at": "document_start"
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["src/content/index.js"],
+      "run_at": "document_idle"
     }
   ],
   "web_accessible_resources": [

--- a/scripts/build-scripts.cjs
+++ b/scripts/build-scripts.cjs
@@ -65,6 +65,19 @@ async function buildAll() {
     });
     console.log('✔ content script built with esbuild -> dist/src/content/index.js');
 
+    // Build early document_start bootstrap
+    await build({
+      entryPoints: ['src/content/early.ts'],
+      bundle: true,
+      outfile: 'dist/src/content/early.js',
+      platform: 'browser',
+      format: 'iife',
+      target: ['es2020'],
+      sourcemap: false,
+      minify: false
+    });
+    console.log('✔ early content script built with esbuild -> dist/src/content/early.js');
+
     // Clean up temp file
     const fs = require('fs');
     if (fs.existsSync(tempContentPath)) {

--- a/src/content/early.ts
+++ b/src/content/early.ts
@@ -1,0 +1,15 @@
+import { debugSync } from "../utils/logger";
+import { applyShield, ensurePreInjectCss } from "./instant-shield";
+
+(() => {
+  const root = document.documentElement;
+  if (root.hasAttribute("data-udr-early")) {
+    debugSync("[Early] document_start bootstrap already applied");
+    return;
+  }
+
+  root.setAttribute("data-udr-early", "1");
+  applyShield();
+  ensurePreInjectCss();
+  debugSync("[Early] Applied shield and pre-inject CSS at document_start");
+})();

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -10,14 +10,12 @@ import { debugSync, initDebugCache, updateDebugCache } from "../utils/logger";
 import { applyPhotonInverter, removePhotonInverter } from "./algorithms/photon-inverter";
 import { applyChromaSemantic, resetChromaSemantic } from "./algorithms/chroma-semantic";
 import { buildCss, ensureStyleTag } from "./style-template";
-import { waitForDocumentReady, isDocumentBodyReady } from "../utils/document-ready";
+import { waitForDocumentReady, waitForPageLoad, isDocumentBodyReady } from "../utils/document-ready";
+import { applyShield, removeShield, ensurePreInjectCss, removePreInjectCss, isShieldActive, isPreInjectApplied } from "./instant-shield";
 
 let worker: Worker | null = null;
 let applied = false;
-let preInjected = false;
-let preInjectTag: HTMLStyleElement | null = null;
 let currentMode: Settings["mode"] | null = null;
-let shieldActive = false;
 
 (async () => {
   await initDebugCache();
@@ -37,51 +35,6 @@ async function effectiveSettingsFor(url: string, base: Settings): Promise<{ use:
   if (typeof per.enabled === "boolean") merged.enabled = per.enabled;
 
   return { use: merged, excluded };
-}
-
-// THE INSTANT SHIELD
-// Injects a brute-force filter immediately to prevent blinding the user
-function applyShield() {
-  // Prevent duplicate injection
-  if (document.getElementById('udr-shield')) {
-    debugSync('[Shield] Shield already active, skipping');
-    return;
-  }
-
-  const shield = document.createElement('style');
-  shield.id = 'udr-shield';
-  // 1. Invert the whole page
-  // 2. Rotate hue 180deg to restore colors (roughly)
-  // 3. Set background to white (which becomes black when inverted)
-  shield.textContent = `
-    html { 
-      filter: invert(1) hue-rotate(180deg) !important; 
-      background-color: white !important;
-    }
-    img, video, iframe {
-      filter: invert(1) hue-rotate(180deg) !important;
-      opacity: 0.8;
-    }
-  `;
-  document.documentElement.appendChild(shield);
-  shieldActive = true;
-  debugSync('[Shield] Instant Shield applied');
-}
-
-// THE HANDOVER
-// Called when the smart algorithm (Chroma) has finished its first pass
-function removeShield() {
-  const shield = document.getElementById('udr-shield');
-  if (shield) {
-    // Optional: Add a CSS transition class to body for smooth fade
-    setTimeout(() => {
-      shield.remove();
-      shieldActive = false;
-      debugSync('[Shield] Shield removed, handover complete');
-    }, 50); 
-  } else {
-    debugSync('[Shield] No shield to remove');
-  }
 }
 
 // PASSIVE MODE
@@ -110,37 +63,6 @@ function applyPassiveMode() {
   document.head.appendChild(style);
   
   debugSync('[UltraDark] Passive Mode applied - images dimmed, backgrounds untouched');
-}
-
-const PRE_INJECT_CSS = `
-html,
-body {
-  background-color: #1a1a1a !important;
-  color: #e0e0e0 !important;
-}`;
-
-function ensurePreInjectCss() {
-  if (!preInjectTag) {
-    preInjectTag = document.createElement('style');
-    preInjectTag.id = 'udr-preinject';
-    preInjectTag.textContent = PRE_INJECT_CSS;
-  }
-
-  if (!preInjectTag.isConnected) {
-    // Prefer head but fall back to documentElement to run as early as possible
-    const parent = document.head || document.documentElement;
-    parent.prepend(preInjectTag);
-  }
-
-  preInjected = true;
-}
-
-function removePreInjectCss() {
-  if (preInjectTag?.parentNode) {
-    preInjectTag.parentNode.removeChild(preInjectTag);
-  }
-
-  preInjected = false;
 }
 
 function hueRotateFromBlueShift(blueShift: number): number {
@@ -190,7 +112,7 @@ function applyCss(s: Settings) {
   }
   
   // Remove the shield now that the intelligent engine is ready
-  if (shieldActive) {
+  if (isShieldActive()) {
     removeShield();
   }
 
@@ -235,7 +157,7 @@ function removeCss() {
   removePreInjectCss();
   
   // Remove the instant shield if active
-  if (shieldActive) {
+  if (isShieldActive()) {
     removeShield();
   }
   
@@ -392,14 +314,14 @@ async function tick() {
   if (!use.enabled || excluded) {
     debugSync('Skipping - extension disabled or URL excluded:', location.href);
     if (applied) removeCss();
-    else if (preInjected) removePreInjectCss();
-    else if (shieldActive) removeShield();
+    else if (isPreInjectApplied()) removePreInjectCss();
+    else if (isShieldActive()) removeShield();
     return;
   }
 
   // Apply Instant Shield immediately to prevent white flash
   // This happens BEFORE waiting for document ready
-  if (!applied && !shieldActive && !preInjected) {
+  if (!applied && !isShieldActive() && !isPreInjectApplied()) {
     applyShield();
   }
 
@@ -413,13 +335,20 @@ async function tick() {
     // Proceed anyway - algorithms have their own fallback mechanisms
   }
 
+  try {
+    await waitForPageLoad();
+    debugSync('Window load completed, running photon inverter after full page load');
+  } catch (error) {
+    debugSync('⚠️ Timeout waiting for window load, proceeding with current DOM:', error);
+  }
+
   // Check if site is already dark (unless forceDarkMode is set for this site)
   // Only run detection if we haven't already applied our theme
   // This prevents false positives from detecting our own styles
   const per = use.perSite[origin] || {};
   const shouldDetectDark = use.detectDarkSites && !per.forceDarkMode;
   
-  if (shouldDetectDark && !applied && !preInjected && !shieldActive && isAlreadyDarkTheme()) {
+  if (shouldDetectDark && !applied && !isPreInjectApplied() && !isShieldActive() && isAlreadyDarkTheme()) {
     debugSync('Site already uses dark theme, engaging Passive Mode');
     applyPassiveMode();
     return; // STOP. Do not run Chroma or Shield.

--- a/src/content/instant-shield.ts
+++ b/src/content/instant-shield.ts
@@ -1,0 +1,86 @@
+import { debugSync } from "../utils/logger";
+
+const SHIELD_ID = "udr-shield";
+const PREINJECT_ID = "udr-preinject";
+
+export const PRE_INJECT_CSS = `
+html,
+body {
+  background-color: #1a1a1a !important;
+  color: #e0e0e0 !important;
+}`;
+
+export function applyShield(): boolean {
+  if (document.getElementById(SHIELD_ID)) {
+    debugSync("[Shield] Shield already active, skipping");
+    return false;
+  }
+
+  const shield = document.createElement("style");
+  shield.id = SHIELD_ID;
+  shield.textContent = `
+    html { 
+      filter: invert(1) hue-rotate(180deg) !important; 
+      background-color: white !important;
+    }
+    img, video, iframe {
+      filter: invert(1) hue-rotate(180deg) !important;
+      opacity: 0.8;
+    }
+  `;
+  document.documentElement.appendChild(shield);
+  debugSync("[Shield] Instant Shield applied");
+  return true;
+}
+
+export function removeShield(): boolean {
+  const shield = document.getElementById(SHIELD_ID);
+  if (shield) {
+    setTimeout(() => {
+      shield.remove();
+      debugSync("[Shield] Shield removed, handover complete");
+    }, 50);
+    return true;
+  }
+
+  debugSync("[Shield] No shield to remove");
+  return false;
+}
+
+export function isShieldActive(): boolean {
+  return Boolean(document.getElementById(SHIELD_ID));
+}
+
+export function ensurePreInjectCss(): boolean {
+  const existing = document.getElementById(PREINJECT_ID) as HTMLStyleElement | null;
+  if (existing) {
+    if (!existing.isConnected) {
+      (document.head || document.documentElement).prepend(existing);
+      debugSync("[PreInject] Re-attached existing pre-inject style");
+      return true;
+    }
+    return false;
+  }
+
+  const preInjectTag = document.createElement("style");
+  preInjectTag.id = PREINJECT_ID;
+  preInjectTag.textContent = PRE_INJECT_CSS;
+  const parent = document.head || document.documentElement;
+  parent.prepend(preInjectTag);
+  debugSync("[PreInject] Applied pre-inject CSS");
+  return true;
+}
+
+export function removePreInjectCss(): boolean {
+  const preInjectTag = document.getElementById(PREINJECT_ID);
+  if (preInjectTag?.parentNode) {
+    preInjectTag.parentNode.removeChild(preInjectTag);
+    debugSync("[PreInject] Removed pre-inject CSS");
+    return true;
+  }
+  return false;
+}
+
+export function isPreInjectApplied(): boolean {
+  return Boolean(document.getElementById(PREINJECT_ID));
+}

--- a/src/utils/document-ready.ts
+++ b/src/utils/document-ready.ts
@@ -54,3 +54,21 @@ export async function waitForDocumentReady(): Promise<void> {
 export function isDocumentBodyReady(): boolean {
   return document.body !== null && document.body !== undefined;
 }
+
+/**
+ * Wait for the full page load event so that computed styles are stable
+ */
+export async function waitForPageLoad(timeoutMs = 8000): Promise<void> {
+  if (document.readyState === 'complete') return Promise.resolve();
+
+  return new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Timeout waiting for window.load'));
+    }, timeoutMs);
+
+    window.addEventListener('load', () => {
+      clearTimeout(timeout);
+      resolve();
+    }, { once: true });
+  });
+}


### PR DESCRIPTION
## Summary
- split the content script into an early document_start bootstrap for shield/pre-inject and a document_idle main script
- share shield/pre-inject helpers so the photon inverter runs after window load without double injections
- update the build pipeline and manifest to ship the new early content script

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947015e8fc08330837e1e4f1dad6119)