### PR TITLE
Add two-phase content scripts for photon inverter

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,8 +26,13 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["src/content/index.js"],
+      "js": ["src/content/early.js"],
       "run_at": "document_start"
+    },
+    {
+      "matches": ["<all_urls>"],
+      "js": ["src/content/index.js"],
+      "run_at": "document_idle"
     }
   ],
   "web_accessible_resources": [

--- a/scripts/build-scripts.cjs
+++ b/scripts/build-scripts.cjs
@@ -39,6 +39,19 @@ async function buildAll() {
     });
     console.log('✔ optimizer worker built with esbuild -> dist/assets/optimizer-worker.js');
 
+    // Build early content script for instant shield/pre-inject
+    await build({
+      entryPoints: ['src/content/early.ts'],
+      bundle: true,
+      outfile: 'dist/src/content/early.js',
+      platform: 'browser',
+      format: 'iife',
+      target: ['es2020'],
+      sourcemap: false,
+      minify: false
+    });
+    console.log('✔ early content script built with esbuild -> dist/src/content/early.js');
+
     // Read content script source and replace worker import
     let contentSource = readFileSync('src/content/index.ts', 'utf-8');
     

--- a/src/content/early.ts
+++ b/src/content/early.ts
@@ -1,0 +1,70 @@
+import type { Settings } from "../types/settings";
+import { getSettings } from "../utils/storage";
+import { urlExcluded } from "../utils/regex";
+import { debugSync, initDebugCache } from "../utils/logger";
+
+const PRE_INJECT_CSS = `
+html,
+body {
+  background-color: #1a1a1a !important;
+  color: #e0e0e0 !important;
+}`;
+
+function shouldEnable(settings: Settings): boolean {
+  const origin = new URL(location.href).origin;
+  const per = settings.perSite[origin] || {};
+  const excluded = per.exclude === true || urlExcluded(location.href, settings.excludeRegex);
+
+  const enabled = typeof per.enabled === "boolean" ? per.enabled : settings.enabled;
+  return enabled && !excluded;
+}
+
+function applyEarlyShield() {
+  if (document.getElementById("udr-shield")) {
+    return;
+  }
+
+  const shield = document.createElement("style");
+  shield.id = "udr-shield";
+  shield.textContent = `
+    html { 
+      filter: invert(1) hue-rotate(180deg) !important; 
+      background-color: white !important;
+    }
+    img, video, iframe {
+      filter: invert(1) hue-rotate(180deg) !important;
+      opacity: 0.8;
+    }
+  `;
+  document.documentElement.appendChild(shield);
+}
+
+function applyPreInjectCss() {
+  if (document.getElementById("udr-preinject")) {
+    return;
+  }
+
+  const style = document.createElement("style");
+  style.id = "udr-preinject";
+  style.textContent = PRE_INJECT_CSS;
+  (document.head || document.documentElement).prepend(style);
+}
+
+async function initEarly() {
+  await initDebugCache();
+  debugSync("[Early] content script starting");
+
+  const settings = await getSettings();
+  if (!shouldEnable(settings)) {
+    debugSync("[Early] Skipping early apply (disabled or excluded)");
+    return;
+  }
+
+  applyPreInjectCss();
+  applyEarlyShield();
+  debugSync("[Early] Pre-inject and shield applied");
+}
+
+initEarly().catch((error) => {
+  console.error("[UltraDark][Early] Failed to initialize early script", error);
+});

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -119,6 +119,17 @@ body {
   color: #e0e0e0 !important;
 }`;
 
+function syncEarlyArtifacts() {
+  const existingShield = document.getElementById('udr-shield');
+  shieldActive = !!existingShield;
+
+  const existingPreInject = document.getElementById('udr-preinject') as HTMLStyleElement | null;
+  if (existingPreInject) {
+    preInjectTag = existingPreInject;
+    preInjected = true;
+  }
+}
+
 function ensurePreInjectCss() {
   if (!preInjectTag) {
     preInjectTag = document.createElement('style');
@@ -387,6 +398,7 @@ async function tick() {
   const { use, excluded } = await effectiveSettingsFor(location.href, s);
 
   const origin = new URL(location.href).origin;
+  syncEarlyArtifacts();
 
   // Check if should skip due to exclusion
   if (!use.enabled || excluded) {


### PR DESCRIPTION
## Summary
- add a dedicated early content script to apply the instant shield and pre-inject CSS at document_start
- switch the main content script to run at document_idle for bookmarklet-like timing
- update the build pipeline to output the new early content script bundle

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947015e8fc08330837e1e4f1dad6119)